### PR TITLE
chore(electronics): add .gitignore file

### DIFF
--- a/electronics/.gitignore
+++ b/electronics/.gitignore
@@ -1,0 +1,26 @@
+# Temporary files
+*.000
+*.bak
+*.bck
+*.lck
+*.kicad_pcb-bak
+*.kicad_sch-bak
+*.kicad_prl
+*.sch-bak
+*~
+_autosave-*
+*.tmp
+*-save.pro
+*-save.kicad_pcb
+fp-info-cache
+/build
+
+# Netlist files (exported from Eeschema)
+*.net
+
+# Autorouter files (exported from Pcbnew)
+*.dsn
+*.ses
+
+# Footprint association file (exported from Pcbnew)
+*.cmp


### PR DESCRIPTION
### Description
This pull request adds a `.gitignore` file to the `electronics` module.
The goal is to prevent unnecessary build artifacts, logs, and temporary files from being tracked in version control.

### Related Issue
Closes #14 

### Changes introduced
- Added `.gitignore` in the `electronics` module.  