### PR TITLE
chore: add kicad backup folder and gerber files to gitignore

### DIFF
--- a/electronics/.gitignore
+++ b/electronics/.gitignore
@@ -24,3 +24,10 @@ fp-info-cache
 
 # Footprint association file (exported from Pcbnew)
 *.cmp
+
+# Kicad default backup folder
+*-backups/
+
+# Gerber files
+*.g*
+*.drl


### PR DESCRIPTION
This PR updates the `.gitignore` file to exclude common KiCad auto-generated files.

It adds rules to ignore:
- The `backups/` directory created by KiCad for project backups.
- Gerber files (`*.gbr`, `*.gbl`, etc.) which are manufacturing outputs, not source files.

This helps keep the repository clean and focused on the source schematic and layout files.