### PR TITLE
Allow configuring calibration retract angle

### DIFF
--- a/firmware/MotionControllerRP/src/hw_config.h
+++ b/firmware/MotionControllerRP/src/hw_config.h
@@ -40,6 +40,11 @@ constexpr float HOMING_CURRENT    = 0.15f;       // range 0..1
 // degrees from home position
 constexpr float CALIBRATION_RANGE = 83; 
 
+// degrees to retract after homing, before starting calibration run
+// can be used to center the mid-point or to avoid non-linear encoder
+// measurements at the beginning of the calibration run.
+constexpr float CALIBRATION_RETRACT_ANGLE = 0.0f;
+
 // velocity of the magnetic field during calibration (lower is more accurate)
 constexpr float CALIBRATION_FIELD_VELOCITY = 20.0f; 
 

--- a/firmware/MotionControllerRP/src/robot_joint/robot_joint.cpp
+++ b/firmware/MotionControllerRP/src/robot_joint/robot_joint.cpp
@@ -57,7 +57,7 @@ bool RobotJoint::calibrate(bool print_measurements) {
   bool homing_ok = homing_controller.run_blocking(servo_controller, -HOMING_VELOCITY, 
                                                   360.0f*DEG_TO_RAD, HOMING_CURRENT,
                                                   ENCODER_ANGLE_TO_ROTOR_ANGLE,
-                                                  0.0f);
+                                                  CALIBRATION_RETRACT_ANGLE*DEG_TO_RAD);
   if(homing_ok == false) {
     LOG_ERROR("Joint-%i: Calibration failed due to unsuccessful homing sequence", joint_idx);
     return false;


### PR DESCRIPTION
We tried to build the project at [FAFO](https://fa-fo.de/) and had trouble to achieve good calibration results, despite having a strong magnetic field at the sensor.
It turned out that the selected homing position was too far out, which lead to non-linear encoder readings at the start and end of the homing run. This caused oscillations and buggy behavior, as well as an off-set mid-point.
Patching the calibration routine to retract about 18 degrees after homing perfectly solved our problems. So here is a PR to expose that as a constant in the hw_config file, as it might be useful for others.

In the homing section of the config is a "Not implemented yet" for a const "HOMING_FINISH_POS". What was the plan here? Was this meant as a retract value for all homing calls? If that's the case, I could implement that instead and update the PR.